### PR TITLE
[FEAT] EC2 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,3 +11,19 @@ module "vpc" {
   vpc_cidr           = var.vpc_cidr
   public_subnet_cidr = var.public_subnet_cidr
 }
+
+# --- 2. API 서버 (EC2) 모듈 호출 ---
+module "api_server" {
+  source = "./modules/ec2"
+
+  # (1) 루트 변수 전달
+  project_name  = var.project_name
+  instance_type = var.ec2_instance_type
+  ami_id        = var.ec2_ami_id
+
+  # (2) ★ VPC 모듈의 '결과물'을 EC2 모듈의 '입력값'으로 전달
+  vpc_id    = module.vpc.vpc_id
+  subnet_id = module.vpc.public_subnet_id
+
+  ec2_key_name = var.ec2_key_name
+}

--- a/main.tf
+++ b/main.tf
@@ -12,18 +12,28 @@ module "vpc" {
   public_subnet_cidr = var.public_subnet_cidr
 }
 
+module "security" {
+  source = "./modules/security"
+
+  # VPC 모듈의 결과물(vpc_id)을 전달
+  vpc_id       = module.vpc.vpc_id 
+  project_name = var.project_name
+}
+
 # --- 2. API 서버 (EC2) 모듈 호출 ---
 module "api_server" {
   source = "./modules/ec2"
 
-  # (1) 루트 변수 전달
+  # 루트 변수 전달
   project_name  = var.project_name
   instance_type = var.ec2_instance_type
   ami_id        = var.ec2_ami_id
 
-  # (2) ★ VPC 모듈의 '결과물'을 EC2 모듈의 '입력값'으로 전달
+  # VPC 모듈의 '결과물'을 EC2 모듈의 '입력값'으로 전달
   vpc_id    = module.vpc.vpc_id
   subnet_id = module.vpc.public_subnet_id
+
+  api_sg_id = module.security.api_sg_id
 
   ec2_key_name = var.ec2_key_name
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -5,6 +5,7 @@ resource "aws_instance" "api_server" {
 
   # (VPC 모듈의 결과물 + 이 파일 1번에서 만든 방화벽)
   subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
   vpc_security_group_ids      = [var.api_sg_id]
   
   # (중요) EC2에 접속할 SSH 키 이름

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,23 @@
+# ---  EC2 인스턴스 (서버) 생성 ---
+resource "aws_instance" "api_server" {
+  ami           = var.ami_id      # (루트에서 전달받음)
+  instance_type = var.instance_type # (루트에서 전달받음)
+
+  # (VPC 모듈의 결과물 + 이 파일 1번에서 만든 방화벽)
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.api_sg_id]
+  
+  # (중요) EC2에 접속할 SSH 키 이름
+  key_name                    = var.ec2_key_name # (variables.tf에 추가할 변수)
+  
+  # (서버 부팅 시 실행할 스크립트 - 예시)
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get update
+              sudo apt-get install -y default-jre # (e.g., Java 설치)
+              EOF
+
+  tags = {
+    Name = "${var.project_name}-api-server"
+  }
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ip" {
+  description = "EC2 인스턴스의 공인 IP 주소"
+  value       = aws_instance.api_server.public_ip
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,30 @@
+variable "project_name" {
+  description = "태그에 사용할 프로젝트 이름 (루트에서 전달받음)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "EC2가 생성될 VPC의 ID (vpc 모듈에서 전달받음)"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "EC2가 생성될 서브넷 ID (vpc 모듈에서 전달받음)"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 인스턴스 타입 (e.g., t3.micro)"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ami_id" {
+  description = "EC2가 사용할 Amazon Machine Image ID"
+  type        = string
+}
+
+variable "ec2_key_name" {
+  description = "EC2 접속용 SSH 키 페어 이름"
+  type        = string
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -13,6 +13,7 @@ variable "subnet_id" {
   type        = string
 }
 
+
 variable "instance_type" {
   description = "EC2 인스턴스 타입 (e.g., t3.micro)"
   type        = string
@@ -23,6 +24,12 @@ variable "ami_id" {
   description = "EC2가 사용할 Amazon Machine Image ID"
   type        = string
 }
+
+variable "api_sg_id" {
+  description = "API 서버용 보안 그룹 ID (security 모듈에서 전달받음)"
+  type        = string
+}
+
 
 variable "ec2_key_name" {
   description = "EC2 접속용 SSH 키 페어 이름"

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "api_sg" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] #추후 변경 필요
+    cidr_blocks = ["0.0.0.0/0"] # 추후 변경 필요
   }
 
   # 8080번 포트 (Spring API): 모든 IP에서 접속 허용

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -1,0 +1,36 @@
+resource "aws_security_group" "api_sg" {
+  name        = "${var.project_name}-api-sg"
+  description = "API 서버용 보안 그룹"
+  vpc_id      = var.vpc_id # (VPC 모듈에서 ID를 받아옴)
+
+  # --- 인바운드(Inbound) 규칙 (서버로 들어오는 트래픽) ---
+  
+  # 22번 포트 (SSH): '내 IP'에서만 접속 허용 (보안)
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] #추후 변경 필요
+  }
+
+  # 8080번 포트 (Spring API): 모든 IP에서 접속 허용
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # --- 아웃바운드(Egress) 규칙 (서버에서 나가는 트래픽) ---
+  # 모든 트래픽 허용 (e.g., git pull, apt update 등)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1" # (모든 프로토콜)
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-api-sg"
+  }
+}

--- a/modules/security/outputs.tf
+++ b/modules/security/outputs.tf
@@ -1,0 +1,4 @@
+output "api_sg_id" {
+  description = "API 서버 보안 그룹 ID"
+  value       = aws_security_group.api_sg.id
+}

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -1,0 +1,9 @@
+variable "project_name" {
+  description = "태그에 사용할 프로젝트 이름 (루트에서 전달받음)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "EC2가 생성될 VPC의 ID (vpc 모듈에서 전달받음)"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,8 @@ output "public_route_table_id" {
   description = "생성된 퍼블릭 라우트 테이블 ID (루트에 보고)"
   value       = module.vpc.public_route_table_id
 }
+
+output "api_server_public_ip" {
+  description = "API 서버 (EC2)의 공인 IP 주소"
+  value       = module.api_server.public_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,23 @@ variable "public_subnet_cidr" {
   type        = string
   default     = "10.10.1.0/24"
 }
+
+# --- EC2 변수 추가 ---
+variable "ec2_instance_type" {
+  description = "API 서버 인스턴스 타입"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ec2_ami_id" {
+  description = "API 서버가 사용할 AMI ID (Ubuntu 22.04 LTS, ap-northeast-2)"
+  type        = string
+  # (참고) 이 값은 AWS에서 'Ubuntu 22.04 LTS (HVM), amd64' 서울 리전 AMI ID입니다.
+  default     = "ami-04a32252a0a2f8b50"
+}
+
+variable "ec2_key_name" {
+  description = "AWS에 등록된 EC2 키 페어 이름"
+  type        = string
+  # (default 없음, tfvars에서 꼭 입력하도록 강제)
+}


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

EC2 모듈 추가 및 main.tf에 반영
보안그룹 모듈 추가

<br>

## 2. 🔗 연관 이슈 (Issue)

* **(e.g., Closes #1 )**

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
➜  Terraform git:(feature/#1-add-ec2) terraform init

Initializing the backend...
Initializing modules...
- api_server in modules/ec2
- security in modules/security

Initializing provider plugins...
- Reusing previous version of hashicorp/aws from the dependency lock file
- Using previously-installed hashicorp/aws v5.100.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
➜  Terraform git:(feature/#1-add-ec2) terraform plan
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.api_server.aws_instance.api_server will be created
  + resource "aws_instance" "api_server" {
      + ami                                  = "ami-04a32252a0a2f8b50"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + enable_primary_ipv6                  = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t3.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "sai"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-07943663686251075"
      + tags                                 = {
          + "Name" = "sai-project-dev-api-server"
        }
      + tags_all                             = {
          + "Name" = "sai-project-dev-api-server"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "2607612388baaa8344fd2ea71a0a6c6ede3785b6"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)
    }

  # module.security.aws_security_group.api_sg will be created
  + resource "aws_security_group" "api_sg" {
      + arn                    = (known after apply)
      + description            = "API 서버용 보안 그룹"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 8080
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 8080
            },
        ]
      + name                   = "sai-project-dev-api-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "sai-project-dev-api-sg"
        }
      + tags_all               = {
          + "Name" = "sai-project-dev-api-sg"
        }
      + vpc_id                 = "vpc-0a5eb8d5550662611"
    }

  # module.vpc.aws_internet_gateway.main_igw will be updated in-place
  ~ resource "aws_internet_gateway" "main_igw" {
        id       = "igw-058d35d2aa511fa32"
      ~ tags     = {
          ~ "Name" = "sai-project-igw" -> "sai-project-dev-igw"
        }
      ~ tags_all = {
          ~ "Name" = "sai-project-igw" -> "sai-project-dev-igw"
        }
        # (3 unchanged attributes hidden)
    }

  # module.vpc.aws_route_table.public_rt will be updated in-place
  ~ resource "aws_route_table" "public_rt" {
        id               = "rtb-0011b8918b34f593c"
      ~ tags             = {
          ~ "Name" = "sai-project-public-rt" -> "sai-project-dev-public-rt"
        }
      ~ tags_all         = {
          ~ "Name" = "sai-project-public-rt" -> "sai-project-dev-public-rt"
        }
        # (5 unchanged attributes hidden)
    }

  # module.vpc.aws_subnet.public will be updated in-place
  ~ resource "aws_subnet" "public" {
        id                                             = "subnet-07943663686251075"
      ~ tags                                           = {
          ~ "Name" = "sai-project-public-subnet" -> "sai-project-dev-public-subnet"
        }
      ~ tags_all                                       = {
          ~ "Name" = "sai-project-public-subnet" -> "sai-project-dev-public-subnet"
        }
        # (15 unchanged attributes hidden)
    }

  # module.vpc.aws_vpc.main will be updated in-place
  ~ resource "aws_vpc" "main" {
        id                                   = "vpc-0a5eb8d5550662611"
      ~ tags                                 = {
          ~ "Name" = "sai-project-vpc" -> "sai-project-dev-vpc"
        }
      ~ tags_all                             = {
          ~ "Name" = "sai-project-vpc" -> "sai-project-dev-vpc"
        }
        # (14 unchanged attributes hidden)
    }

Plan: 2 to add, 4 to change, 0 to destroy.

Changes to Outputs:
  + api_server_public_ip  = (known after apply)

Plan: X to add, Y to change, Z to destroy.