### PR TITLE
[FIX] DB 서브넷 그룹으로 수정

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "vpc" {
   aws_region         = var.aws_region
   vpc_cidr           = var.vpc_cidr
   public_subnet_cidr = var.public_subnet_cidr
+  public_subnet_cidr2 = var.public_subnet_cidr2
 }
 
 module "security" {
@@ -44,6 +45,7 @@ module "rds" {
 
   project_name       = var.project_name
   public_subnet_id   = module.vpc.public_subnet_id
+  public_subnet_id2  = module.vpc.public_subnet_id2
   rds_sg_id          = module.security.rds_sg_id
 
   db_name            = var.db_name

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -5,7 +5,7 @@
 #  var.public_subnet_id로 전달받아 그룹으로 묶어줍니다.)
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name       = "${var.project_name}-rds-subnet-group"
-  subnet_ids = [var.public_subnet_id] # (EC2와 동일한 서브넷 ID 사용)
+  subnet_ids = [var.public_subnet_id, var.public_subnet_id2] # (EC2와 동일한 서브넷 ID 사용)
 
   tags = {
     Name = "${var.project_name}-rds-subnet-group"

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -8,6 +8,11 @@ variable "public_subnet_id" {
   type        = string
 }
 
+variable "public_subnet_id2" {
+  description = "RDS가 생성될 두번째 서브넷 ID (vpc 모듈에서 전달받음)"
+  type        = string
+}
+
 variable "rds_sg_id" {
     description = "RDS용 보안 그룹 ID (security 모듈에서 전달받음)"
     type        = string

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -58,6 +58,6 @@ resource "aws_route_table_association" "public_assoc" {
 }
 
 resource "aws_route_table_association" "public_assoc_2" {
-  subnet_id      = aws_subnet.public-2.id
+  subnet_id      = aws_subnet.public2.id
   route_table_id = aws_route_table.public_rt.id
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -24,6 +24,14 @@ resource "aws_subnet" "public" {
   tags                    = { Name = "${var.project_name}-public-subnet" }
 }
 
+resource "aws_subnet" "public2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr2
+  availability_zone       = "${var.aws_region}b"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.project_name}-public-subnet-2" }
+}
+
 # --- 4. 라우트 테이블 (Route Table) 생성 ---
 # "퍼블릭 서브넷"이 사용할 '교통 규칙' (네비게이션)
 resource "aws_route_table" "public_rt" {
@@ -46,5 +54,10 @@ resource "aws_route_table" "public_rt" {
 # "방금 만든 '퍼블릭 서브넷'은 '퍼블릭 교통 규칙'을 따른다"
 resource "aws_route_table_association" "public_assoc" {
   subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_route_table_association" "public_assoc_2" {
+  subnet_id      = aws_subnet.public-2.id
   route_table_id = aws_route_table.public_rt.id
 }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -8,6 +8,11 @@ output "public_subnet_id" {
   value       = aws_subnet.public.id
 }
 
+output "public_subnet_id2" {
+  description = "생성된 두번째 퍼블릭 서브넷의 ID (루트에 보고)"
+  value       = aws_subnet.public2.id
+}
+
 output "public_route_table_id" {
   description = "생성된 퍼블릭 라우트 테이블 ID (루트에 보고)"
   value       = aws_route_table.public_rt.id

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -19,3 +19,8 @@ variable "public_subnet_cidr" {
   description = "퍼블릭 서브넷 IP 대역"
   type        = string
 }
+
+variable "public_subnet_cidr2" {
+  description = "두번째 퍼블릭 서브넷 IP 대역"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "public_subnet_id" {
   value       = module.vpc.public_subnet_id
 }
 
+output "public_subnet_id2" {
+  description = "생성된 두번째 퍼블릭 서브넷의 ID (루트에 보고)"
+  value       = module.vpc.public_subnet_id2
+}
+
 output "public_route_table_id" {
   description = "생성된 퍼블릭 라우트 테이블 ID (루트에 보고)"
   value       = module.vpc.public_route_table_id

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "public_subnet_cidr" {
   default     = "10.10.1.0/24"
 }
 
+variable "public_subnet_cidr2" {
+  description = "두번째 퍼블릭 서브넷 IP 대역"
+  type        = string
+  default     = "10.10.2.0/24"
+}
+
 # --- EC2 변수 추가 ---
 variable "ec2_instance_type" {
   description = "API 서버 인스턴스 타입"


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

vpc 모듈에 public2 추가

<br>

## 2. 🔗 연관 이슈 (Issue)

* **(e.g., Closes #123)**

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
output "vpc_id" {
  description = "생성된 VPC의 ID (루트에 보고)"
  value       = module.vpc.vpc_id
}

output "public_subnet_id" {
  description = "생성된 퍼블릭 서브넷의 ID (루트에 보고)"
  value       = module.vpc.public_subnet_id
}

output "public_subnet_id2" {
  description = "생성된 두번째 퍼블릭 서브넷의 ID (루트에 보고)"
  value       = module.vpc.public_subnet_id2
}

output "public_route_table_id" {
  description = "생성된 퍼블릭 라우트 테이블 ID (루트에 보고)"
  value       = module.vpc.public_route_table_id
}

output "api_server_public_ip" {
  description = "API 서버 (EC2)의 공인 IP 주소"
  value       = module.api_server.public_ip
}

output "rds_endpoint" {
  description = "RDS 데이터베이스 엔드포인트"
  value       = module.rds.db_endpoint
}

Plan: X to add, Y to change, Z to destroy.