### PR TITLE
[FEAT] 소켓용 ec2 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,25 @@ module "api_server" {
   vpc_id    = module.vpc.vpc_id
   subnet_id = module.vpc.public_subnet_id
 
-  api_sg_id = module.security.api_sg_id
+  
+  sg_id = module.security.api_sg_id
+
+  ec2_key_name = var.ec2_key_name
+}
+
+module "socket_server" {
+  source = "./modules/ec2"
+
+  # 루트 변수 전달
+  project_name  = var.project_name
+  instance_type = var.ec2_instance_type
+  ami_id        = var.ec2_ami_id
+
+  # VPC 모듈의 '결과물'을 EC2 모듈의 '입력값'으로 전달
+  vpc_id    = module.vpc.vpc_id
+  subnet_id = module.vpc.public_subnet_id
+
+  sg_id = module.security.socket_sg_id
 
   ec2_key_name = var.ec2_key_name
 }
@@ -52,3 +70,4 @@ module "rds" {
   db_username        = var.db_username
   db_password        = var.db_password
 }
+

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "api_server" {
   # (VPC 모듈의 결과물 + 이 파일 1번에서 만든 방화벽)
   subnet_id                   = var.subnet_id
   associate_public_ip_address = true
-  vpc_security_group_ids      = [var.api_sg_id]
+  vpc_security_group_ids      = [var.sg_id]
   
   # (중요) EC2에 접속할 SSH 키 이름
   key_name                    = var.ec2_key_name # (variables.tf에 추가할 변수)

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -25,8 +25,8 @@ variable "ami_id" {
   type        = string
 }
 
-variable "api_sg_id" {
-  description = "API 서버용 보안 그룹 ID (security 모듈에서 전달받음)"
+variable "sg_id" {
+  description = "보안 그룹 ID (security 모듈에서 전달받음)"
   type        = string
 }
 

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -21,6 +21,13 @@ resource "aws_security_group" "api_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # --- 아웃바운드(Egress) 규칙 (서버에서 나가는 트래픽) ---
   # 모든 트래픽 허용 (e.g., git pull, apt update 등)
   egress {

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -98,4 +98,4 @@ resource "aws_security_group" "socket_sg" {
   tags = {
     Name = "${var.project_name}-socket-sg"
   }
-} 
+}

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -61,3 +61,34 @@ resource "aws_security_group" "rds_sg" {
     Name = "${var.project_name}-rds-sg"
   }
 }
+
+resource "aws_security_group" "socket_sg" {
+  name        = "${var.project_name}-socket-sg"
+  description = "Security group for Socket server"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-socket-sg"
+  }
+} 

--- a/modules/security/outputs.tf
+++ b/modules/security/outputs.tf
@@ -7,3 +7,8 @@ output "rds_sg_id" {
   description = "RDS 보안 그룹 ID"
   value       = aws_security_group.rds_sg.id
 }
+
+output "socket_sg_id" {
+  description = "Socket 서버 보안 그룹 ID"
+  value       = aws_security_group.socket_sg.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "api_server_public_ip" {
   value       = module.api_server.public_ip
 }
 
+output "socket_server_public_ip" {
+  description = "Socket 서버 (EC2)의 공인 IP 주소"
+  value       = module.socket_server.public_ip
+}
+
 output "rds_endpoint" {
   description = "RDS 데이터베이스 엔드포인트"
   value       = module.rds.db_endpoint


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

* 소켓용 보안그룹 추가
* 루트 main.tf 수정

<br>

## 2. 🔗 연관 이슈 (Issue)

* **(e.g., Closes #6 )**

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
  Terraform git:(feature/#6-socket-ec2) terraform plan
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.rds.aws_db_instance.rds_mysql will be updated in-place
  ~ resource "aws_db_instance" "rds_mysql" {
        id                                    = "db-JQDT4KXBAGJX6GXYS7NI6KGOHY"
        tags                                  = {
            "Name" = "sai-project-dev-rds-mysql"
        }
        # (56 unchanged attributes hidden)
    }

  # module.security.aws_security_group.socket_sg will be created
  + resource "aws_security_group" "socket_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for Socket server"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 3000
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 3000
            },
        ]
      + name                   = "sai-project-dev-socket-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "sai-project-dev-socket-sg"
        }
      + tags_all               = {
          + "Name" = "sai-project-dev-socket-sg"
        }
      + vpc_id                 = "vpc-0a5eb8d5550662611"
    }

  # module.socket_server.aws_instance.api_server will be created
  + resource "aws_instance" "api_server" {
      + ami                                  = "ami-0a71e3eb8b23101ed"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + enable_primary_ipv6                  = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t3.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "sai"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-07943663686251075"
      + tags                                 = {
          + "Name" = "sai-project-dev-api-server"
        }
      + tags_all                             = {
          + "Name" = "sai-project-dev-api-server"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "2607612388baaa8344fd2ea71a0a6c6ede3785b6"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)
    }

Plan: 2 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  + socket_server_public_ip = (known after apply)

Plan: X to add, Y to change, Z to destroy.