### PR TITLE
FEAT: Redis 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,8 @@ module "vpc" {
   vpc_cidr           = var.vpc_cidr
   public_subnet_cidr = var.public_subnet_cidr
   public_subnet_cidr2 = var.public_subnet_cidr2
+  private_subnet_cidr = var.private_subnet_cidr
+  private_subnet_cidr2 = var.private_subnet_cidr2
 }
 
 module "security" {
@@ -71,3 +73,13 @@ module "rds" {
   db_password        = var.db_password
 }
 
+module "redis" {
+  source = "./modules/redis"
+
+  project_name       = var.project_name
+  subnet_ids = [
+    module.vpc.private_subnet_id,
+    module.vpc.private_subnet_id2
+  ]
+  redis_sg_id        = module.security.redis_sg_id
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,0 +1,31 @@
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = "${var.project_name}-redis-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.project_name}-redis-subnet-group"
+  }
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id = "${var.project_name}-redis"
+  description = "SAI Project Redis Cluster"
+  node_type = "cache.t3.micro"
+  port = 6379
+
+  automatic_failover_enabled = false
+  num_node_groups = 1
+  replicas_per_node_group = 0
+
+  subnet_group_name = aws_elasticache_subnet_group.redis_subnet_group.name
+  security_group_ids = [var.redis_sg_id]
+
+  engine = "redis"
+  engine_version = "7.0"
+  parameter_group_name = "default.redis7"
+
+  tags = {
+    Name = "${var.project_name}-redis"
+  }
+  
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -27,5 +27,4 @@ resource "aws_elasticache_replication_group" "redis" {
   tags = {
     Name = "${var.project_name}-redis"
   }
-  
 }

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,0 +1,4 @@
+output "redis_endpoint" {
+    description = "Redis 기본 노드 접속 주소"
+    value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+    description = "프로젝트 이름"
+    type        = string
+}
+
+variable "subnet_ids" {
+    description = "Redis가 배포될 서브넷 ID 목록"
+    type        = list(string)
+}
+
+variable "redis_sg_id" {
+    description = "Redis 보안 그룹 ID"
+    type        = string
+}

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -106,3 +106,29 @@ resource "aws_security_group" "socket_sg" {
     Name = "${var.project_name}-socket-sg"
   }
 }
+
+resource "aws_security_group" "redis_sg" {
+  name        = "${var.project_name}-redis-sg"
+  description = "Security group for Redis"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow Redis access from API and Socket servers"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    security_groups = [aws_security_group.api_sg.id, aws_security_group.socket_sg.id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-redis-sg"
+  }
+  
+}

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -130,5 +130,4 @@ resource "aws_security_group" "redis_sg" {
   tags = {
     Name = "${var.project_name}-redis-sg"
   }
-  
 }

--- a/modules/security/outputs.tf
+++ b/modules/security/outputs.tf
@@ -12,3 +12,8 @@ output "socket_sg_id" {
   description = "Socket 서버 보안 그룹 ID"
   value       = aws_security_group.socket_sg.id
 }
+
+output "redis_sg_id" {
+  description = "Redis 서버 보안 그룹 ID"
+  value       = aws_security_group.redis_sg.id
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -34,6 +34,21 @@ resource "aws_subnet" "public2" {
   tags                    = { Name = "${var.project_name}-public-subnet-2" }
 }
 
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr
+  availability_zone = "${var.aws_region}a"
+  tags              = { Name = "${var.project_name}-private-subnet" }
+}
+
+resource "aws_subnet" "private2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr2
+  availability_zone = "${var.aws_region}b"
+  tags              = { Name = "${var.project_name}-private-subnet-2" }
+  
+}
+
 # --- 4. 라우트 테이블 (Route Table) 생성 ---
 # "퍼블릭 서브넷"이 사용할 '교통 규칙' (네비게이션)
 resource "aws_route_table" "public_rt" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -46,7 +46,6 @@ resource "aws_subnet" "private2" {
   cidr_block        = var.private_subnet_cidr2
   availability_zone = "${var.aws_region}b"
   tags              = { Name = "${var.project_name}-private-subnet-2" }
-  
 }
 
 # --- 4. 라우트 테이블 (Route Table) 생성 ---

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -13,7 +13,18 @@ output "public_subnet_id2" {
   value       = aws_subnet.public2.id
 }
 
+output "private_subnet_id" {
+  description = "생성된 프라이빗 서브넷의 ID (루트에 보고)"
+  value       = aws_subnet.private.id
+}
+
+output "private_subnet_id2" {
+  description = "생성된 두번째 프라이빗 서브넷의 ID (루트에 보고)"
+  value       = aws_subnet.private2.id
+}
+
 output "public_route_table_id" {
   description = "생성된 퍼블릭 라우트 테이블 ID (루트에 보고)"
   value       = aws_route_table.public_rt.id
 }
+

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -24,3 +24,13 @@ variable "public_subnet_cidr2" {
   description = "두번째 퍼블릭 서브넷 IP 대역"
   type        = string
 }
+
+variable "private_subnet_cidr" {
+  description = "프라이빗 서브넷 IP 대역"
+  type        = string
+}
+
+variable "private_subnet_cidr2" {
+  description = "두번째 프라이빗 서브넷 IP 대역"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,18 @@ variable "public_subnet_cidr2" {
   default     = "10.10.2.0/24"
 }
 
+variable "private_subnet_cidr" {
+  description = "프라이빗 서브넷 IP 대역"
+  type        = string
+  default     = "10.10.3.0/24"
+}
+
+variable "private_subnet_cidr2" {
+  description = "두번째 프라이빗 서브넷 IP 대역"
+  type        = string
+  default     = "10.10.4.0/24"
+}
+
 # --- EC2 변수 추가 ---
 variable "ec2_instance_type" {
   description = "API 서버 인스턴스 타입"


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

* 레디스 추가
<br>

## 2. 🔗 연관 이슈 (Issue)

* **(Closes #8 )**

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
 Terraform git:(dev) ✗ terraform plan
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.security.aws_security_group.socket_sg: Refreshing state... [id=sg-0b1349ec151db684e]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.socket_server.aws_instance.api_server: Refreshing state... [id=i-0e86dd28cc996e475]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.rds.aws_db_instance.rds_mysql will be updated in-place
  ~ resource "aws_db_instance" "rds_mysql" {
        id                                    = "db-JQDT4KXBAGJX6GXYS7NI6KGOHY"
        tags                                  = {
            "Name" = "sai-project-dev-rds-mysql"
        }
        # (56 unchanged attributes hidden)
    }

  # module.redis.aws_elasticache_replication_group.redis will be created
  + resource "aws_elasticache_replication_group" "redis" {
      + apply_immediately              = (known after apply)
      + arn                            = (known after apply)
      + at_rest_encryption_enabled     = (known after apply)
      + auth_token_update_strategy     = "ROTATE"
      + auto_minor_version_upgrade     = (known after apply)
      + automatic_failover_enabled     = false
      + cluster_enabled                = (known after apply)
      + cluster_mode                   = (known after apply)
      + configuration_endpoint_address = (known after apply)
      + data_tiering_enabled           = (known after apply)
      + description                    = "SAI Project Redis Cluster"
      + engine                         = "redis"
      + engine_version                 = "7.0"
      + engine_version_actual          = (known after apply)
      + global_replication_group_id    = (known after apply)
      + id                             = (known after apply)
      + ip_discovery                   = (known after apply)
      + maintenance_window             = (known after apply)
      + member_clusters                = (known after apply)
      + multi_az_enabled               = false
      + network_type                   = (known after apply)
      + node_type                      = "cache.t3.micro"
      + num_cache_clusters             = (known after apply)
      + num_node_groups                = 1
      + parameter_group_name           = "default.redis7"
      + port                           = 6379
      + primary_endpoint_address       = (known after apply)
      + reader_endpoint_address        = (known after apply)
      + replicas_per_node_group        = 0
      + replication_group_id           = "sai-project-dev-redis"
      + security_group_ids             = (known after apply)
      + security_group_names           = (known after apply)
      + snapshot_window                = (known after apply)
      + subnet_group_name              = "sai-project-dev-redis-subnet-group"
      + tags                           = {
          + "Name" = "sai-project-dev-redis"
        }
      + tags_all                       = {
          + "Name" = "sai-project-dev-redis"
        }
      + transit_encryption_enabled     = (known after apply)
      + transit_encryption_mode        = (known after apply)
    }

  # module.redis.aws_elasticache_subnet_group.redis_subnet_group will be created
  + resource "aws_elasticache_subnet_group" "redis_subnet_group" {
      + arn         = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "sai-project-dev-redis-subnet-group"
      + subnet_ids  = (known after apply)
      + tags        = {
          + "Name" = "sai-project-dev-redis-subnet-group"
        }
      + tags_all    = {
          + "Name" = "sai-project-dev-redis-subnet-group"
        }
      + vpc_id      = (known after apply)
    }

  # module.security.aws_security_group.redis_sg will be created
  + resource "aws_security_group" "redis_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for Redis"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = []
              + description      = "Allow Redis access from API and Socket servers"
              + from_port        = 6379
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = [
                  + "sg-0b1349ec151db684e",
                  + "sg-0f242f56c95ddfbf0",
                ]
              + self             = false
              + to_port          = 6379
            },
        ]
      + name                   = "sai-project-dev-redis-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "sai-project-dev-redis-sg"
        }
      + tags_all               = {
          + "Name" = "sai-project-dev-redis-sg"
        }
      + vpc_id                 = "vpc-0a5eb8d5550662611"
    }

  # module.vpc.aws_subnet.private will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-northeast-2a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.10.3.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "sai-project-dev-private-subnet"
        }
      + tags_all                                       = {
          + "Name" = "sai-project-dev-private-subnet"
        }
      + vpc_id                                         = "vpc-0a5eb8d5550662611"
    }

  # module.vpc.aws_subnet.private2 will be created
  + resource "aws_subnet" "private2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-northeast-2b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.10.4.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "sai-project-dev-private-subnet-2"
        }
      + tags_all                                       = {
          + "Name" = "sai-project-dev-private-subnet-2"
        }
      + vpc_id                                         = "vpc-0a5eb8d5550662611"
    }

Plan: 5 to add, 1 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these
actions if you run "terraform apply" now.

Plan: X to add, Y to change, Z to destroy.