### PR TITLE
[FEAT] ALB 추가

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,3 +95,18 @@ module "s3" {
   environment  = var.environment
   bucket_name  = var.s3_bucket_name
 }
+
+module "alb" {
+  source = "./modules/alb"
+
+  project_name       = var.project_name
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids = [
+    module.vpc.public_subnet_id,
+    module.vpc.public_subnet_id2
+  ]
+  alb_sg_id          = module.security.alb_sg_id
+
+  api_instance_id = module.api_server.instance_id
+  socket_instance_id = module.socket_server.instance_id
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,0 +1,80 @@
+resource "aws_lb" "this" {
+    name               = "${var.project_name}-alb"
+    internal           = false
+    load_balancer_type = "application"
+    security_groups    = [var.alb_sg_id]
+    subnets            = var.subnet_ids
+    
+    tags = {
+        Name = "${var.project_name}-alb"
+    }
+}
+
+resource "aws_lb_target_group" "api_tg" {
+    name     = "${var.project_name}-api-tg"
+    port     = 8080
+    protocol = "HTTP"
+    vpc_id   = var.vpc_id
+
+    health_check {
+        path                = "/healthz"
+        
+    }
+}
+
+resource "aws_lb_target_group" "socket_tg" {
+    name     = "${var.project_name}-socket-tg"
+    port     = 3000
+    protocol = "HTTP"
+    vpc_id   = var.vpc_id
+
+    stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
+    } 
+
+    health_check {
+    path = "/healthz" # 소켓 서버 헬스체크 경로
+    }
+}
+
+resource "aws_lb_listener" "http" {
+    load_balancer_arn = aws_lb.this.arn
+    port              = "80"
+    protocol          = "HTTP"
+
+    default_action {
+        type             = "forward"
+        target_group_arn = aws_lb_target_group.socket_tg.arn
+    }
+}
+
+resource "aws_lb_listener_rule" "api_rule" {
+    listener_arn = aws_lb_listener.http.arn
+    priority     = 100
+
+    action {
+        type             = "forward"
+        target_group_arn = aws_lb_target_group.api_tg.arn
+    }
+
+    condition {
+        path_pattern {
+            values = ["/api/*"]
+        }
+    }
+}
+
+resource "aws_lb_target_group_attachment" "api_attachment" {
+    target_group_arn = aws_lb_target_group.api_tg.arn
+    target_id        = var.api_instance_id
+    port             = 8080
+}
+
+resource "aws_lb_target_group_attachment" "socket_attachment" {
+    target_group_arn = aws_lb_target_group.socket_tg.arn
+    target_id        = var.socket_instance_id
+    port             = 3000
+  
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -18,7 +18,6 @@ resource "aws_lb_target_group" "api_tg" {
 
     health_check {
         path                = "/healthz"
-        
     }
 }
 
@@ -29,13 +28,13 @@ resource "aws_lb_target_group" "socket_tg" {
     vpc_id   = var.vpc_id
 
     stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 86400
-    enabled         = true
+        type            = "lb_cookie"
+        cookie_duration = 86400
+        enabled         = true
     } 
 
     health_check {
-    path = "/healthz" # 소켓 서버 헬스체크 경로
+        path = "/healthz" # 소켓 서버 헬스체크 경로
     }
 }
 
@@ -76,5 +75,4 @@ resource "aws_lb_target_group_attachment" "socket_attachment" {
     target_group_arn = aws_lb_target_group.socket_tg.arn
     target_id        = var.socket_instance_id
     port             = 3000
-  
 }

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,0 +1,26 @@
+output "alb_dns_name" {
+  description = "Application Load Balancer의 DNS 이름"
+  value       = aws_lb.this.dns_name
+}
+
+#추후 도메인 연결에 필요
+output "alb_zone_id" {
+  description = "Application Load Balancer의 호스팅 영역 ID"
+  value       = aws_lb.this.zone_id
+}
+
+output "alb_arn" {
+  description = "Application Load Balancer의 ARN"
+  value       = aws_lb.this.arn
+}
+
+
+output "api_target_group_arn" {
+  description = "API 타겟 그룹 ARN"
+  value       = aws_lb_target_group.api_tg.arn
+}
+
+output "socket_target_group_arn" {
+  description = "소켓 타겟 그룹 ARN"
+  value       = aws_lb_target_group.socket_tg.arn
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -22,7 +22,6 @@ variable "alb_sg_id" {
 variable "api_instance_id" {
     description = "API 서버 인스턴스 ID"
     type        = string
-  
 }
 
 variable "socket_instance_id" {

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,0 +1,31 @@
+variable "project_name" {
+    description = "프로젝트 이름"
+    type        = string
+    default     = "sai-project"
+}
+
+variable "vpc_id" {
+    description = "ALB가 생성될 VPC의 ID"
+    type        = string
+}
+
+variable "subnet_ids" {
+    description = "ALB가 생성될 서브넷 ID 목록"
+    type        = list(string)
+}
+
+variable "alb_sg_id" {
+    description = "ALB에 할당할 보안 그룹 ID"
+    type        = string
+}
+
+variable "api_instance_id" {
+    description = "API 서버 인스턴스 ID"
+    type        = string
+  
+}
+
+variable "socket_instance_id" {
+    description = "Socket 서버 인스턴스 ID"
+    type        = string
+}

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "api_server" {
 }
 
 
-# EC2가 S3에 접근할 수 있도록 권한 부여
+# EC2가 S3에 접근할 수 있도록 권한 부여 //TODO: ECR 분리
 resource "aws_iam_role_policy" "s3_access" {
   name = "${var.project_name}-${var.component_name}-s3-policy"
   role = aws_iam_role.this.id
@@ -56,25 +56,35 @@ resource "aws_iam_role_policy" "s3_access" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
+      # --- 기존 S3 권한 ---
       {
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket"
-        ]
-        Resource = [
-          var.s3_bucket_arn
-        ]
+        Sid      = "S3List"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.s3_bucket_arn]
       },
       {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject"
+        Sid      = "S3Access"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["${var.s3_bucket_arn}/*"]
+      },
+      # --- [추가] ECR 권한 (콘솔 내용 복사) ---
+      {
+        Sid      = "ECRLogin"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Sid      = "ECRPull"
+        Effect   = "Allow"
+        Action   = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
         ]
-        Resource = [
-          "${var.s3_bucket_arn}/*"
-        ]
+        Resource = "*"
       }
     ]
   })

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "api_server" {
 }
 
 
-# EC2가 S3에 접근할 수 있도록 권한 부여 //TODO: ECR 분리
+# EC2가 S3에 접근할 수 있도록 권한 부여 //TODO:ECR 권한 분리
 resource "aws_iam_role_policy" "s3_access" {
   name = "${var.project_name}-${var.component_name}-s3-policy"
   role = aws_iam_role.this.id

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -7,3 +7,8 @@ output "iam_role_arn" {
   description = "The ARN of the IAM role"
   value       = aws_iam_role.this.arn
 }
+
+output "instance_id" {
+  description = "EC2 인스턴스 ID"
+  value       = aws_instance.this.id
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -10,5 +10,5 @@ output "iam_role_arn" {
 
 output "instance_id" {
   description = "EC2 인스턴스 ID"
-  value       = aws_instance.this.id
+  value       = aws_instance.api_server.id
 }

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -142,13 +142,13 @@ resource "aws_security_group" "alb_sg" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-  }   
+  }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] 
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -131,3 +131,34 @@ resource "aws_security_group" "redis_sg" {
     Name = "${var.project_name}-redis-sg"
   }
 }
+
+resource "aws_security_group" "alb_sg" {
+  name         = "${var.project_name}-alb-sg"
+  description = "Security Group for ALB"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }   
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] 
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-alb-sg"
+  }
+}

--- a/modules/security/outputs.tf
+++ b/modules/security/outputs.tf
@@ -17,3 +17,8 @@ output "redis_sg_id" {
   description = "Redis 서버 보안 그룹 ID"
   value       = aws_security_group.redis_sg.id
 }
+
+output "alb_sg_id" {
+  description = "ALB 보안 그룹 ID"
+  value       = aws_security_group.alb_sg.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,13 @@ output "rds_endpoint" {
   description = "RDS 데이터베이스 엔드포인트"
   value       = module.rds.db_endpoint
 }
+
+output "final_api_url" {
+  description = "최종 API 접속 주소"
+  value       = "http://${module.alb.alb_dns_name}"
+}
+
+output "final_alb_dns" {
+  description = "도메인 설정용 DNS 값"
+  value       = module.alb.alb_dns_name
+}


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

* alb 추가


<br>

## 2. 🔗 연관 이슈 (Issue)

* **Closes #12 **

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
  Terraform git:(feature/#12-alb) ✗ terraform plan
╷
│ Error: Reference to undeclared resource
│ 
│   on modules/ec2/outputs.tf line 13, in output "instance_id":
│   13:   value       = aws_instance.this.id
│ 
│ A managed resource "aws_instance" "this" has not been declared in module.api_server.
╵
╷
│ Error: Reference to undeclared resource
│ 
│   on modules/ec2/outputs.tf line 13, in output "instance_id":
│   13:   value       = aws_instance.this.id
│ 
│ A managed resource "aws_instance" "this" has not been declared in module.socket_server.
╵
➜  Terraform git:(feature/#12-alb) ✗ terraform plan
module.api_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-api-ec2-role]
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.socket_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-socket-ec2-role]
module.s3.aws_s3_bucket.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_public_access_block.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_ownership_controls.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_cors_configuration.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_policy.main_policy: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.private2: Refreshing state... [id=subnet-09818ac3dabf44dd8]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_subnet.private: Refreshing state... [id=subnet-06b399bf6c6340b68]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.security.aws_security_group.socket_sg: Refreshing state... [id=sg-0b1349ec151db684e]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.security.aws_security_group.redis_sg: Refreshing state... [id=sg-0fd12327f15f4af9c]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.redis.aws_elasticache_subnet_group.redis_subnet_group: Refreshing state... [id=sai-project-dev-redis-subnet-group]
module.redis.aws_elasticache_replication_group.redis: Refreshing state... [id=sai-project-dev-redis]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]
module.socket_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-socket-ec2-role:sai-project-dev-socket-s3-policy]
module.socket_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-socket-instance-profile]
module.api_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-api-ec2-role:sai-project-dev-api-s3-policy]
module.api_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-api-instance-profile]
module.socket_server.aws_instance.api_server: Refreshing state... [id=i-0e86dd28cc996e475]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.alb.aws_lb.this will be created
  + resource "aws_lb" "this" {
      + arn                                                          = (known after apply)
      + arn_suffix                                                   = (known after apply)
      + client_keep_alive                                            = 3600
      + desync_mitigation_mode                                       = "defensive"
      + dns_name                                                     = (known after apply)
      + drop_invalid_header_fields                                   = false
      + enable_deletion_protection                                   = false
      + enable_http2                                                 = true
      + enable_tls_version_and_cipher_suite_headers                  = false
      + enable_waf_fail_open                                         = false
      + enable_xff_client_port                                       = false
      + enable_zonal_shift                                           = false
      + enforce_security_group_inbound_rules_on_private_link_traffic = (known after apply)
      + id                                                           = (known after apply)
      + idle_timeout                                                 = 60
      + internal                                                     = false
      + ip_address_type                                              = (known after apply)
      + load_balancer_type                                           = "application"
      + name                                                         = "sai-project-dev-alb"
      + name_prefix                                                  = (known after apply)
      + preserve_host_header                                         = false
      + security_groups                                              = (known after apply)
      + subnets                                                      = [
          + "subnet-063547efea85bfd04",
          + "subnet-07943663686251075",
        ]
      + tags                                                         = {
          + "Name" = "sai-project-dev-alb"
        }
      + tags_all                                                     = {
          + "Name" = "sai-project-dev-alb"
        }
      + vpc_id                                                       = (known after apply)
      + xff_header_processing_mode                                   = "append"
      + zone_id                                                      = (known after apply)
    }

  # module.alb.aws_lb_listener.http will be created
  + resource "aws_lb_listener" "http" {
      + arn                                                                   = (known after apply)
      + id                                                                    = (known after apply)
      + load_balancer_arn                                                     = (known after apply)
      + port                                                                  = 80
      + protocol                                                              = "HTTP"
      + routing_http_request_x_amzn_mtls_clientcert_header_name               = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_issuer_header_name        = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_leaf_header_name          = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_subject_header_name       = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_validity_header_name      = (known after apply)
      + routing_http_request_x_amzn_tls_cipher_suite_header_name              = (known after apply)
      + routing_http_request_x_amzn_tls_version_header_name                   = (known after apply)
      + routing_http_response_access_control_allow_credentials_header_value   = (known after apply)
      + routing_http_response_access_control_allow_headers_header_value       = (known after apply)
      + routing_http_response_access_control_allow_methods_header_value       = (known after apply)
      + routing_http_response_access_control_allow_origin_header_value        = (known after apply)
      + routing_http_response_access_control_expose_headers_header_value      = (known after apply)
      + routing_http_response_access_control_max_age_header_value             = (known after apply)
      + routing_http_response_content_security_policy_header_value            = (known after apply)
      + routing_http_response_server_enabled                                  = (known after apply)
      + routing_http_response_strict_transport_security_header_value          = (known after apply)
      + routing_http_response_x_content_type_options_header_value             = (known after apply)
      + routing_http_response_x_frame_options_header_value                    = (known after apply)
      + ssl_policy                                                            = (known after apply)
      + tags_all                                                              = (known after apply)
      + tcp_idle_timeout_seconds                                              = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }
    }

  # module.alb.aws_lb_listener_rule.api_rule will be created
  + resource "aws_lb_listener_rule" "api_rule" {
      + arn          = (known after apply)
      + id           = (known after apply)
      + listener_arn = (known after apply)
      + priority     = 100
      + tags_all     = (known after apply)

      + action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }

      + condition {
          + path_pattern {
              + values = [
                  + "/api/*",
                ]
            }
        }
    }

  # module.alb.aws_lb_target_group.api_tg will be created
  + resource "aws_lb_target_group" "api_tg" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = (known after apply)
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancer_arns                 = (known after apply)
      + load_balancing_algorithm_type      = (known after apply)
      + load_balancing_anomaly_mitigation  = (known after apply)
      + load_balancing_cross_zone_enabled  = (known after apply)
      + name                               = "sai-project-dev-api-tg"
      + name_prefix                        = (known after apply)
      + port                               = 8080
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = (known after apply)
      + target_type                        = "instance"
      + vpc_id                             = "vpc-0a5eb8d5550662611"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 30
          + matcher             = (known after apply)
          + path                = "/healthz"
          + port                = "traffic-port"
          + protocol            = "HTTP"
          + timeout             = (known after apply)
          + unhealthy_threshold = 3
        }
    }

  # module.alb.aws_lb_target_group.socket_tg will be created
  + resource "aws_lb_target_group" "socket_tg" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = (known after apply)
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancer_arns                 = (known after apply)
      + load_balancing_algorithm_type      = (known after apply)
      + load_balancing_anomaly_mitigation  = (known after apply)
      + load_balancing_cross_zone_enabled  = (known after apply)
      + name                               = "sai-project-dev-socket-tg"
      + name_prefix                        = (known after apply)
      + port                               = 3000
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = (known after apply)
      + target_type                        = "instance"
      + vpc_id                             = "vpc-0a5eb8d5550662611"

      + health_check {
          + enabled             = true
          + healthy_threshold   = 3
          + interval            = 30
          + matcher             = (known after apply)
          + path                = "/healthz"
          + port                = "traffic-port"
          + protocol            = "HTTP"
          + timeout             = (known after apply)
          + unhealthy_threshold = 3
        }

      + stickiness {
          + cookie_duration = 86400
          + enabled         = true
          + type            = "lb_cookie"
        }
    }

  # module.alb.aws_lb_target_group_attachment.api_attachment will be created
  + resource "aws_lb_target_group_attachment" "api_attachment" {
      + id               = (known after apply)
      + port             = 8080
      + target_group_arn = (known after apply)
      + target_id        = "i-0ce0fb4184bec1cba"
    }

  # module.alb.aws_lb_target_group_attachment.socket_attachment will be created
  + resource "aws_lb_target_group_attachment" "socket_attachment" {
      + id               = (known after apply)
      + port             = 3000
      + target_group_arn = (known after apply)
      + target_id        = "i-0e86dd28cc996e475"
    }

  # module.api_server.aws_iam_role_policy.s3_access will be updated in-place
  ~ resource "aws_iam_role_policy" "s3_access" {
        id     = "sai-project-dev-api-ec2-role:sai-project-dev-api-s3-policy"
        name   = "sai-project-dev-api-s3-policy"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      + Sid      = "S3List"
                        # (3 unchanged attributes hidden)
                    },
                  ~ {
                      + Sid      = "S3Access"
                        # (3 unchanged attributes hidden)
                    },
                  + {
                      + Action   = [
                          + "ecr:GetAuthorizationToken",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "ECRLogin"
                    },
                  + {
                      + Action   = [
                          + "ecr:BatchCheckLayerAvailability",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "ECRPull"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.rds.aws_db_instance.rds_mysql will be updated in-place
  ~ resource "aws_db_instance" "rds_mysql" {
        id                                    = "db-JQDT4KXBAGJX6GXYS7NI6KGOHY"
        tags                                  = {
            "Name" = "sai-project-dev-rds-mysql"
        }
        # (56 unchanged attributes hidden)
    }

  # module.redis.aws_elasticache_replication_group.redis will be updated in-place
  ~ resource "aws_elasticache_replication_group" "redis" {
        id                         = "sai-project-dev-redis"
        tags                       = {
            "Name" = "sai-project-dev-redis"
        }
        # (34 unchanged attributes hidden)
    }

  # module.security.aws_security_group.alb_sg will be created
  + resource "aws_security_group" "alb_sg" {
      + arn                    = (known after apply)
      + description            = "Security Group for ALB"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
        ]
      + name                   = "sai-project-dev-alb-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "sai-project-dev-alb-sg"
        }
      + tags_all               = {
          + "Name" = "sai-project-dev-alb-sg"
        }
      + vpc_id                 = "vpc-0a5eb8d5550662611"
    }

Plan: 8 to add, 3 to change, 0 to destroy.

Changes to Outputs:
  + final_alb_dns           = (known after apply)
  + final_api_url           = (known after apply)

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.

Plan: X to add, Y to change, Z to destroy.