### PR TITLE
[FEAT] Route53 도메인 설정

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,3 +110,11 @@ module "alb" {
   api_instance_id = module.api_server.instance_id
   socket_instance_id = module.socket_server.instance_id
 }
+
+module "route53" {
+  source = "./modules/route53"
+
+  domain_name    = "talkwithsai.com"
+  alb_dns_name   = module.alb.alb_dns_name
+  alb_zone_id    = module.alb.alb_zone_id
+}

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -14,4 +14,4 @@ resource "aws_route53_record" "api" {
     }
 }
 
-//프론트엔드 추가
+//TODO: 프론트엔드 추가

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_zone" "main" {
+    name = var.domain_name
+}
+
+resource "aws_route53_record" "api" {
+    zone_id = aws_route53_zone.main.zone_id
+    name    = "api.${var.domain_name}"
+    type    = "A"
+
+    alias {
+        name                   = var.alb_dns_name
+        zone_id                = var.alb_zone_id
+        evaluate_target_health = true
+    }
+}
+
+//프론트엔드 추가

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -1,0 +1,4 @@
+output "name_servers" {
+    description = "가비아에 등록할 네임서버 목록"
+    value       = aws_route53_zone.main.name_servers
+}

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,0 +1,14 @@
+variable "domain_name" {
+  description = "구입한 도메인 이름 (예: mydomain.com)"
+  type        = string
+}
+
+variable "alb_dns_name" {
+  description = "ALB 접속 주소 (API 연결용)"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "ALB Zone ID (API 연결용)"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,5 +46,4 @@ output "final_alb_dns" {
 output "name_servers" {
   description = "Route53 네임서버"
   value       = module.route53.name_servers
-  
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,3 +42,9 @@ output "final_alb_dns" {
   description = "도메인 설정용 DNS 값"
   value       = module.alb.alb_dns_name
 }
+
+output "name_servers" {
+  description = "Route53 네임서버"
+  value       = module.route53.name_servers
+  
+}


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

* Route 53추가


<br>

## 2. 🔗 연관 이슈 (Issue)

* **Closes #14 **

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
 Terraform git:(feature/#14-route53) terraform plan
module.route53.aws_route53_zone.main: Refreshing state... [id=Z03568747PXQTBWPMWQ]
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.socket_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-socket-ec2-role]
module.api_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-api-ec2-role]
module.s3.aws_s3_bucket.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_ownership_controls.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_public_access_block.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_cors_configuration.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_policy.main_policy: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_subnet.private2: Refreshing state... [id=subnet-09818ac3dabf44dd8]
module.vpc.aws_subnet.private: Refreshing state... [id=subnet-06b399bf6c6340b68]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.alb.aws_lb_target_group.socket_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe]
module.security.aws_security_group.alb_sg: Refreshing state... [id=sg-05a53588211cba29c]
module.security.aws_security_group.socket_sg: Refreshing state... [id=sg-0b1349ec151db684e]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.alb.aws_lb_target_group.api_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.redis.aws_elasticache_subnet_group.redis_subnet_group: Refreshing state... [id=sai-project-dev-redis-subnet-group]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.alb.aws_lb.this: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:loadbalancer/app/sai-project-dev-alb/def15abfca15ece5]
module.security.aws_security_group.redis_sg: Refreshing state... [id=sg-0fd12327f15f4af9c]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.alb.aws_lb_listener.http: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2]
module.route53.aws_route53_record.api: Refreshing state... [id=Z03568747PXQTBWPMWQ_api.talkwithsai.com_A]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]
module.alb.aws_lb_listener_rule.api_rule: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2/7b699a13a1094064]
module.redis.aws_elasticache_replication_group.redis: Refreshing state... [id=sai-project-dev-redis]
module.api_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-api-ec2-role:sai-project-dev-api-s3-policy]
module.api_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-api-instance-profile]
module.socket_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-socket-ec2-role:sai-project-dev-socket-s3-policy]
module.socket_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-socket-instance-profile]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]
module.socket_server.aws_instance.api_server: Refreshing state... [id=i-0e86dd28cc996e475]
module.alb.aws_lb_target_group_attachment.api_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed-20251123155329408800000001]
module.alb.aws_lb_target_group_attachment.socket_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe-20251123155329482900000002]

No changes. Your infrastructure matches the configuration.
Plan: X to add, Y to change, Z to destroy.