### PR TITLE
[FEAT] https 적용

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,40 @@ module "security" {
   project_name = var.project_name
 }
 
+module "s3" {
+  source = "./modules/s3"
+
+  project_name = var.project_name
+  environment  = var.environment
+  bucket_name  = var.s3_bucket_name
+}
+
+# --- 3. RDS 모듈 호출 ---
+module "rds" {
+  source = "./modules/rds"
+
+  project_name       = var.project_name
+  public_subnet_id   = module.vpc.public_subnet_id
+  public_subnet_id2  = module.vpc.public_subnet_id2
+  rds_sg_id          = module.security.rds_sg_id
+
+  db_name            = var.db_name
+  db_username        = var.db_username
+  db_password        = var.db_password
+}
+
+module "redis" {
+  source = "./modules/redis"
+
+  project_name       = var.project_name
+  subnet_ids = [
+    module.vpc.private_subnet_id,
+    module.vpc.private_subnet_id2
+  ]
+  redis_sg_id        = module.security.redis_sg_id
+}
+
+
 # --- 2. API 서버 (EC2) 모듈 호출 ---
 module "api_server" {
   source = "./modules/ec2"
@@ -63,37 +97,19 @@ module "socket_server" {
   ec2_key_name = var.ec2_key_name
 }
 
-# --- 3. RDS 모듈 호출 ---
-module "rds" {
-  source = "./modules/rds"
+module "route53" {
+  source = "./modules/route53"
 
-  project_name       = var.project_name
-  public_subnet_id   = module.vpc.public_subnet_id
-  public_subnet_id2  = module.vpc.public_subnet_id2
-  rds_sg_id          = module.security.rds_sg_id
-
-  db_name            = var.db_name
-  db_username        = var.db_username
-  db_password        = var.db_password
+  domain_name    = "talkwithsai.com"
+  alb_dns_name   = module.alb.alb_dns_name
+  alb_zone_id    = module.alb.alb_zone_id
 }
 
-module "redis" {
-  source = "./modules/redis"
+module "acm" {
+  source = "./modules/acm"
 
-  project_name       = var.project_name
-  subnet_ids = [
-    module.vpc.private_subnet_id,
-    module.vpc.private_subnet_id2
-  ]
-  redis_sg_id        = module.security.redis_sg_id
-}
-
-module "s3" {
-  source = "./modules/s3"
-
-  project_name = var.project_name
-  environment  = var.environment
-  bucket_name  = var.s3_bucket_name
+  domain_name      = "talkwithsai.com"
+  route53_zone_id  = module.route53.zone_id
 }
 
 module "alb" {
@@ -111,19 +127,4 @@ module "alb" {
   socket_instance_id = module.socket_server.instance_id
 
   acm_certificate_arn = module.acm.aws_acm_certificate_arn
-}
-
-module "route53" {
-  source = "./modules/route53"
-
-  domain_name    = "talkwithsai.com"
-  alb_dns_name   = module.alb.alb_dns_name
-  alb_zone_id    = module.alb.alb_zone_id
-}
-
-module "acm" {
-  source = "./modules/acm"
-
-  domain_name      = "talkwithsai.com"
-  route53_zone_id  = module.route53.zone_id
 }

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,8 @@ module "alb" {
 
   api_instance_id = module.api_server.instance_id
   socket_instance_id = module.socket_server.instance_id
+
+  acm_certificate_arn = module.acm.aws_acm_certificate_arn
 }
 
 module "route53" {
@@ -117,4 +119,11 @@ module "route53" {
   domain_name    = "talkwithsai.com"
   alb_dns_name   = module.alb.alb_dns_name
   alb_zone_id    = module.alb.alb_zone_id
+}
+
+module "acm" {
+  source = "./modules/acm"
+
+  domain_name      = "talkwithsai.com"
+  route53_zone_id  = module.route53.zone_id
 }

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -1,0 +1,32 @@
+resource "aws_acm_certificate" "this" {
+    domain_name       = var.domain_name
+    validation_method = "DNS"
+
+    subject_alternative_names = ["*.${var.domain_name}"]
+    
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+resource "aws_route53_record" "cert_validation" {
+    for_each = {
+        for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+            name   = dvo.resource_record_name
+            type   = dvo.resource_record_type
+            record = dvo.resource_record_value
+        }
+    }
+
+    allow_overwrite = true
+    name    = each.value.name
+    type    = each.value.type
+    zone_id = var.route53_zone_id
+    records = [each.value.record]
+    ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "this" {
+    certificate_arn         = aws_acm_certificate.this.arn
+    validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/modules/acm/outputs.tf
+++ b/modules/acm/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_acm_certificate_arn" {
+    value = aws_acm_certificate.this.arn
+}

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -1,0 +1,9 @@
+variable "domain_name" {
+    description = "인증서를 발급할 도메인 이름"
+    type = string
+}
+
+variable "route53_zone_id" {
+    description = "검증용 레코드를 생성할 Route53 Zone ID"
+    type = string
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -49,8 +49,38 @@ resource "aws_lb_listener" "http" {
     }
 }
 
+resource "aws_lb_listener" "https" {
+    load_balancer_arn = aws_lb.this.arn
+    port              = "443"
+    protocol          = "HTTPS"
+    ssl_policy        = "ELBSecurityPolicy-2016-08"
+    certificate_arn   = var.acm_certificate_arn
+
+    default_action {
+        type             = "forward"
+        target_group_arn = aws_lb_target_group.socket_tg.arn
+    }
+  
+}
+
 resource "aws_lb_listener_rule" "api_rule" {
-    listener_arn = aws_lb_listener.http.arn
+    listener_arn = aws_lb_listener.https.arn
+    priority     = 100
+
+    action {
+        type             = "forward"
+        target_group_arn = aws_lb_target_group.api_tg.arn
+    }
+
+    condition {
+        path_pattern {
+            values = ["/api/*"]
+        }
+    }
+}
+
+resource "aws_lb_listener_rule" "http_api_rule" {
+    listener_arn = aws_lb_listener.http.arn # 80번 리스너에 연결
     priority     = 100
 
     action {

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -53,14 +53,13 @@ resource "aws_lb_listener" "https" {
     load_balancer_arn = aws_lb.this.arn
     port              = "443"
     protocol          = "HTTPS"
-    ssl_policy        = "ELBSecurityPolicy-2016-08"
+    ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
     certificate_arn   = var.acm_certificate_arn
 
     default_action {
         type             = "forward"
         target_group_arn = aws_lb_target_group.socket_tg.arn
     }
-  
 }
 
 resource "aws_lb_listener_rule" "api_rule" {

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -28,3 +28,8 @@ variable "socket_instance_id" {
     description = "Socket 서버 인스턴스 ID"
     type        = string
 }
+
+variable "acm_certificate_arn" {
+  description = "HTTPS 리스너에 적용할 인증서 ARN"
+  type        = string
+}

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -2,3 +2,8 @@ output "name_servers" {
     description = "가비아에 등록할 네임서버 목록"
     value       = aws_route53_zone.main.name_servers
 }
+
+output "zone_id" {
+  description = "Route53 Hosted Zone ID"
+  value       = aws_route53_zone.main.zone_id
+}


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

*EC2 모듈 추가 및 main.tf에 반영


<br>

## 2. 🔗 연관 이슈 (Issue)

* **Closes #16 **

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
terraform plan
module.api_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-api-ec2-role]
module.route53.aws_route53_zone.main: Refreshing state... [id=Z03568747PXQTBWPMWQ]
module.socket_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-socket-ec2-role]
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.s3.aws_s3_bucket.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_public_access_block.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_ownership_controls.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_cors_configuration.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_policy.main_policy: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_subnet.private2: Refreshing state... [id=subnet-09818ac3dabf44dd8]
module.vpc.aws_subnet.private: Refreshing state... [id=subnet-06b399bf6c6340b68]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.security.aws_security_group.socket_sg: Refreshing state... [id=sg-0b1349ec151db684e]
module.security.aws_security_group.alb_sg: Refreshing state... [id=sg-05a53588211cba29c]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.alb.aws_lb_target_group.api_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed]
module.alb.aws_lb_target_group.socket_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.redis.aws_elasticache_subnet_group.redis_subnet_group: Refreshing state... [id=sai-project-dev-redis-subnet-group]
module.alb.aws_lb.this: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:loadbalancer/app/sai-project-dev-alb/def15abfca15ece5]
module.security.aws_security_group.redis_sg: Refreshing state... [id=sg-0fd12327f15f4af9c]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]
module.alb.aws_lb_listener.http: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2]
module.alb.aws_lb_listener_rule.api_rule: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2/7b699a13a1094064]
module.route53.aws_route53_record.api: Refreshing state... [id=Z03568747PXQTBWPMWQ_api.talkwithsai.com_A]
module.redis.aws_elasticache_replication_group.redis: Refreshing state... [id=sai-project-dev-redis]
module.socket_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-socket-ec2-role:sai-project-dev-socket-s3-policy]
module.socket_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-socket-instance-profile]
module.api_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-api-ec2-role:sai-project-dev-api-s3-policy]
module.api_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-api-instance-profile]
module.socket_server.aws_instance.api_server: Refreshing state... [id=i-0e86dd28cc996e475]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]
module.alb.aws_lb_target_group_attachment.socket_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe-20251123155329482900000002]
module.alb.aws_lb_target_group_attachment.api_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed-20251123155329408800000001]

Terraform used the selected providers to generate the following
execution plan. Resource actions are indicated with the following
symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.acm.aws_acm_certificate.this will be created
  + resource "aws_acm_certificate" "this" {
      + arn                       = (known after apply)
      + domain_name               = "talkwithsai.com"
      + domain_validation_options = [
          + {
              + domain_name           = "*.talkwithsai.com"
              + resource_record_name  = (known after apply)
              + resource_record_type  = (known after apply)
              + resource_record_value = (known after apply)
            },
          + {
              + domain_name           = "talkwithsai.com"
              + resource_record_name  = (known after apply)
              + resource_record_type  = (known after apply)
              + resource_record_value = (known after apply)
            },
        ]
      + id                        = (known after apply)
      + key_algorithm             = (known after apply)
      + not_after                 = (known after apply)
      + not_before                = (known after apply)
      + pending_renewal           = (known after apply)
      + renewal_eligibility       = (known after apply)
      + renewal_summary           = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = [
          + "*.talkwithsai.com",
          + "talkwithsai.com",
        ]
      + tags_all                  = (known after apply)
      + type                      = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = "DNS"
    }

  # module.acm.aws_acm_certificate_validation.this will be created
  + resource "aws_acm_certificate_validation" "this" {
      + certificate_arn         = (known after apply)
      + id                      = (known after apply)
      + validation_record_fqdns = (known after apply)
    }

  # module.acm.aws_route53_record.cert_validation["*.talkwithsai.com"] will be created
  + resource "aws_route53_record" "cert_validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z03568747PXQTBWPMWQ"
    }

  # module.acm.aws_route53_record.cert_validation["talkwithsai.com"] will be created
  + resource "aws_route53_record" "cert_validation" {
      + allow_overwrite = true
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = (known after apply)
      + records         = (known after apply)
      + ttl             = 60
      + type            = (known after apply)
      + zone_id         = "Z03568747PXQTBWPMWQ"
    }

  # module.alb.aws_lb_listener.https will be created
  + resource "aws_lb_listener" "https" {
      + arn                                                                   = (known after apply)
      + certificate_arn                                                       = (known after apply)
      + id                                                                    = (known after apply)
      + load_balancer_arn                                                     = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:loadbalancer/app/sai-project-dev-alb/def15abfca15ece5"
      + port                                                                  = 443
      + protocol                                                              = "HTTPS"
      + routing_http_request_x_amzn_mtls_clientcert_header_name               = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_issuer_header_name        = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_leaf_header_name          = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_subject_header_name       = (known after apply)
      + routing_http_request_x_amzn_mtls_clientcert_validity_header_name      = (known after apply)
      + routing_http_request_x_amzn_tls_cipher_suite_header_name              = (known after apply)
      + routing_http_request_x_amzn_tls_version_header_name                   = (known after apply)
      + routing_http_response_access_control_allow_credentials_header_value   = (known after apply)
      + routing_http_response_access_control_allow_headers_header_value       = (known after apply)
      + routing_http_response_access_control_allow_methods_header_value       = (known after apply)
      + routing_http_response_access_control_allow_origin_header_value        = (known after apply)
      + routing_http_response_access_control_expose_headers_header_value      = (known after apply)
      + routing_http_response_access_control_max_age_header_value             = (known after apply)
      + routing_http_response_content_security_policy_header_value            = (known after apply)
      + routing_http_response_server_enabled                                  = (known after apply)
      + routing_http_response_strict_transport_security_header_value          = (known after apply)
      + routing_http_response_x_content_type_options_header_value             = (known after apply)
      + routing_http_response_x_frame_options_header_value                    = (known after apply)
      + ssl_policy                                                            = "ELBSecurityPolicy-2016-08"
      + tags_all                                                              = (known after apply)
      + tcp_idle_timeout_seconds                                              = (known after apply)

      + default_action {
          + order            = (known after apply)
          + target_group_arn = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe"
          + type             = "forward"
        }
    }

  # module.alb.aws_lb_listener_rule.api_rule must be replaced
-/+ resource "aws_lb_listener_rule" "api_rule" {
      ~ arn          = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2/7b699a13a1094064" -> (known after apply)
      ~ id           = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2/7b699a13a1094064" -> (known after apply)
      ~ listener_arn = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2" # forces replacement -> (known after apply) # forces replacement
      - tags         = {} -> null
      ~ tags_all     = {} -> (known after apply)
        # (1 unchanged attribute hidden)

      ~ action {
          ~ order            = 1 -> (known after apply)
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.alb.aws_lb_listener_rule.http_api_rule will be created
  + resource "aws_lb_listener_rule" "http_api_rule" {
      + arn          = (known after apply)
      + id           = (known after apply)
      + listener_arn = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2"
      + priority     = 100
      + tags_all     = (known after apply)

      + action {
          + order            = (known after apply)
          + target_group_arn = "arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed"
          + type             = "forward"
        }

      + condition {
          + path_pattern {
              + values = [
                  + "/api/*",
                ]
            }
        }
    }

  # module.rds.aws_db_instance.rds_mysql will be updated in-place
  ~ resource "aws_db_instance" "rds_mysql" {
        id                                    = "db-JQDT4KXBAGJX6GXYS7NI6KGOHY"
        tags                                  = {
            "Name" = "sai-project-dev-rds-mysql"
        }
        # (56 unchanged attributes hidden)
    }

  # module.redis.aws_elasticache_replication_group.redis will be updated in-place
  ~ resource "aws_elasticache_replication_group" "redis" {
        id                         = "sai-project-dev-redis"
        tags                       = {
            "Name" = "sai-project-dev-redis"
        }
        # (34 unchanged attributes hidden)
    }

Plan: 7 to add, 2 to change, 1 to destroy.
