### PR TITLE
FEAT: 프론트엔드 도메인 연결

### DIFF
--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -14,4 +14,20 @@ resource "aws_route53_record" "api" {
     }
 }
 
-//TODO: 프론트엔드 추가
+resource "aws_route53_record" "frontend_root" {
+    zone_id = aws_route53_zone.main.zone_id
+    name    = var.domain_name
+    type    = "A"
+    ttl    = 600
+
+    records = ["216.198.79.1"]
+}
+
+resource "aws_route53_record" "frontend_www" {
+    zone_id = aws_route53_zone.main.zone_id
+    name    = "www.${var.domain_name}"
+    type    = "CNAME"
+    ttl    = 600
+
+    records = ["e485a016f2f9bd56.vercel-dns-017.com."]
+}


### PR DESCRIPTION
## 1. 📄 PR 요약 (Summary)

(이번 PR에서 어떤 인프라 코드를 변경했는지 요약 설명합니다.)

* Route54 모듈 수정


<br>

## 2. 🔗 연관 이슈 (Issue)

* **(Closes #19 )**

<br>

## 3. 💻 `terraform plan` 실행 결과

(PR을 올리기 전, 로컬에서 `terraform plan`을 실행한 결과를 **반드시** 붙여넣어 주세요.)

<details>
<summary><b>`terraform plan` 결과 펼쳐보기</b></summary>

```hcl
(여기에 'plan' 실행 결과를 붙여넣어 주세요)
 Terraform git:(feature/#19-vercel-domain) terraform plan
module.route53.aws_route53_zone.main: Refreshing state... [id=Z03568747PXQTBWPMWQ]
module.socket_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-socket-ec2-role]
module.api_server.aws_iam_role.this: Refreshing state... [id=sai-project-dev-api-ec2-role]
module.vpc.aws_vpc.main: Refreshing state... [id=vpc-0a5eb8d5550662611]
module.acm.aws_acm_certificate.this: Refreshing state... [id=arn:aws:acm:ap-northeast-2:679277545841:certificate/c29f1f71-408a-4102-b553-e0d587b01862]
module.s3.aws_s3_bucket.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_public_access_block.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_ownership_controls.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_cors_configuration.this: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.s3.aws_s3_bucket_policy.main_policy: Refreshing state... [id=sai-final-bucket-asdfasdf]
module.vpc.aws_internet_gateway.main_igw: Refreshing state... [id=igw-058d35d2aa511fa32]
module.vpc.aws_subnet.public2: Refreshing state... [id=subnet-063547efea85bfd04]
module.vpc.aws_subnet.public: Refreshing state... [id=subnet-07943663686251075]
module.vpc.aws_subnet.private2: Refreshing state... [id=subnet-09818ac3dabf44dd8]
module.vpc.aws_subnet.private: Refreshing state... [id=subnet-06b399bf6c6340b68]
module.security.aws_security_group.rds_sg: Refreshing state... [id=sg-0721c717874f7f28d]
module.security.aws_security_group.api_sg: Refreshing state... [id=sg-0f242f56c95ddfbf0]
module.security.aws_security_group.alb_sg: Refreshing state... [id=sg-05a53588211cba29c]
module.security.aws_security_group.socket_sg: Refreshing state... [id=sg-0b1349ec151db684e]
module.alb.aws_lb_target_group.api_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed]
module.vpc.aws_route_table.public_rt: Refreshing state... [id=rtb-0011b8918b34f593c]
module.rds.aws_db_subnet_group.rds_subnet_group: Refreshing state... [id=sai-project-dev-rds-subnet-group]
module.alb.aws_lb_target_group.socket_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe]
module.redis.aws_elasticache_subnet_group.redis_subnet_group: Refreshing state... [id=sai-project-dev-redis-subnet-group]
module.alb.aws_lb.this: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:loadbalancer/app/sai-project-dev-alb/def15abfca15ece5]
module.security.aws_security_group.redis_sg: Refreshing state... [id=sg-0fd12327f15f4af9c]
module.vpc.aws_route_table_association.public_assoc: Refreshing state... [id=rtbassoc-0563b26bbdfd6a43e]
module.vpc.aws_route_table_association.public_assoc_2: Refreshing state... [id=rtbassoc-0231f236f9c0e55c9]
module.alb.aws_lb_listener.http: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2]
module.redis.aws_elasticache_replication_group.redis: Refreshing state... [id=sai-project-dev-redis]
module.rds.aws_db_instance.rds_mysql: Refreshing state... [id=db-JQDT4KXBAGJX6GXYS7NI6KGOHY]
module.alb.aws_lb_listener_rule.http_api_rule: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/2a6c7e26ab8b90b2/2a90a2bab1a5c270]
module.socket_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-socket-ec2-role:sai-project-dev-socket-s3-policy]
module.socket_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-socket-instance-profile]
module.route53.aws_route53_record.api: Refreshing state... [id=Z03568747PXQTBWPMWQ_api.talkwithsai.com_A]
module.acm.aws_route53_record.cert_validation["talkwithsai.com"]: Refreshing state... [id=Z03568747PXQTBWPMWQ__bf33648e47a3c74cd1c14a277c5af71c.talkwithsai.com._CNAME]
module.acm.aws_route53_record.cert_validation["*.talkwithsai.com"]: Refreshing state... [id=Z03568747PXQTBWPMWQ__bf33648e47a3c74cd1c14a277c5af71c.talkwithsai.com._CNAME]
module.socket_server.aws_instance.api_server: Refreshing state... [id=i-0e86dd28cc996e475]
module.api_server.aws_iam_role_policy.s3_access: Refreshing state... [id=sai-project-dev-api-ec2-role:sai-project-dev-api-s3-policy]
module.api_server.aws_iam_instance_profile.this: Refreshing state... [id=sai-project-dev-api-instance-profile]
module.api_server.aws_instance.api_server: Refreshing state... [id=i-0ce0fb4184bec1cba]
module.acm.aws_acm_certificate_validation.this: Refreshing state... [id=2025-11-25 04:15:59.62 +0000 UTC]
module.alb.aws_lb_listener.https: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener/app/sai-project-dev-alb/def15abfca15ece5/26a1cb31b7774afc]
module.alb.aws_lb_listener_rule.api_rule: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:listener-rule/app/sai-project-dev-alb/def15abfca15ece5/26a1cb31b7774afc/d777f96d4a239e78]
module.alb.aws_lb_target_group_attachment.socket_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-socket-tg/30269002cceae3fe-20251123155329482900000002]
module.alb.aws_lb_target_group_attachment.api_attachment: Refreshing state... [id=arn:aws:elasticloadbalancing:ap-northeast-2:679277545841:targetgroup/sai-project-dev-api-tg/a1023017fcf195ed-20251123155329408800000001]

Terraform used the selected providers to generate the
following execution plan. Resource actions are indicated with
the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.acm.aws_acm_certificate.this will be updated in-place
  ~ resource "aws_acm_certificate" "this" {
        id                        = "arn:aws:acm:ap-northeast-2:679277545841:certificate/c29f1f71-408a-4102-b553-e0d587b01862"
        tags                      = {}
        # (15 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.rds.aws_db_instance.rds_mysql will be updated in-place
  ~ resource "aws_db_instance" "rds_mysql" {
        id                                    = "db-JQDT4KXBAGJX6GXYS7NI6KGOHY"
        tags                                  = {
            "Name" = "sai-project-dev-rds-mysql"
        }
        # (56 unchanged attributes hidden)
    }

  # module.redis.aws_elasticache_replication_group.redis will be updated in-place
  ~ resource "aws_elasticache_replication_group" "redis" {
        id                         = "sai-project-dev-redis"
        tags                       = {
            "Name" = "sai-project-dev-redis"
        }
        # (34 unchanged attributes hidden)
    }

  # module.route53.aws_route53_record.frontend_root will be created
  + resource "aws_route53_record" "frontend_root" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "talkwithsai.com"
      + records         = [
          + "216.198.79.1",
        ]
      + ttl             = 600
      + type            = "A"
      + zone_id         = "Z03568747PXQTBWPMWQ"
    }

  # module.route53.aws_route53_record.frontend_www will be created
  + resource "aws_route53_record" "frontend_www" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "www.talkwithsai.com"
      + records         = [
          + "e485a016f2f9bd56.vercel-dns-017.com.",
        ]
      + ttl             = 600
      + type            = "CNAME"
      + zone_id         = "Z03568747PXQTBWPMWQ"
    }

Plan: 2 to add, 3 to change, 0 to destroy.

